### PR TITLE
トップページ商品一覧表示・詳細ページ実装2

### DIFF
--- a/app/assets/stylesheets/modules/_items_index.scss
+++ b/app/assets/stylesheets/modules/_items_index.scss
@@ -166,6 +166,16 @@
 
       .products-index {
         padding: 70px 100px;
+        .pagination {
+          text-align: center;
+          a {
+            text-decoration: none;
+            color: $font-black;
+          }
+          a:hover {
+            text-decoration: underline $main-color;
+          }
+        }
         .title {
           @include title();
           &__border {
@@ -176,13 +186,15 @@
           width: 80%;
           margin: 0 auto;
           display: flex;
+          flex-wrap: wrap;
           justify-content: center;
           .list {
             background-color: $basic-white;
             text-decoration: none;
             width: 220px;
             margin: auto 30px;
-            font-size: 0;
+            margin-bottom: 50px;
+            font-size: 30px;
             a {
               text-decoration: none;
               color: $font-black;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :set_item, only: [:show, :destroy]
 
   def index
-    @items = Item.where(buyer_id: nil).order("created_at DESC").limit(3)
+    @items = Item.where(buyer_id: nil).order("created_at DESC").page(params[:page]).per(9)
   end
 
   def show

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,10 +12,10 @@ class Item < ApplicationRecord
   enum status: {"新品、未使用":1, "未使用に近い":2, "目立った傷や汚れなし":3, "やや傷や汚れあり":4, "傷や汚れあり":5, "全体的に状態が悪い":6} ,_prefix: true
 
   def previous
-    Item.where("id < ?", self.id).order("id DESC").first
+    Item.where("id < ?", self.id).where(buyer_id: nil).order("id DESC").first
   end
   
   def next
-    Item.where("id > ?", self.id).order("id ASC").first
+    Item.where("id > ?", self.id).where(buyer_id: nil).order("id ASC").first
   end
 end

--- a/app/views/items/_app_introduction.html.haml
+++ b/app/views/items/_app_introduction.html.haml
@@ -1,0 +1,84 @@
+.theme-visual
+  .content
+    .content__title
+      人生を変えるフリマアプリ
+    .content__text
+      %p FURIMAは 誰でも簡単に出品・購入できる
+      %p フリマアプリです"
+    .content__dl-badge
+      = link_to image_tag('google-play-badge.png', alt: 'google badge', height: '55', width: 'auto', class: ''), "#"
+      = link_to image_tag('Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917.png', alt: 'apple badge', height: '54', width: 'auto', class: ''), "#"
+
+.introduction
+  .title
+    FURIMAが選ばれる3つの理由
+    .title__border
+  %ul.lists
+    %li.list
+      .list__image
+        .number
+          1
+        = image_tag 'pict/pict-reason-01.jpg', class: 'image'
+      .list__subtitle
+        %span 3分
+        ですぐに出品
+      %p.list__text
+        スマホで入力するだけで簡単に出品できる！
+    %li.list
+      .list__image
+        .number
+          2
+        = image_tag 'pict/pict-reason-02.jpg', class: 'image'
+      .list__subtitle
+        %span シンプル
+        で使いやすい
+      %p.list__text
+        めんどくさい入力は必要なく、検索も購入もスムーズ！
+    %li.list
+      .list__image
+        .number
+          3
+        = image_tag 'pict/pict-reason-03.jpg', class: 'image'
+      .list__subtitle
+        手数料
+        %span 業界最安値
+      %p.list__text--center
+        最大3%でお得に出品&購入！
+
+.dl-content
+  .dl-content__title
+    会員数日本一位
+  .dl-content__text
+    %p FURIMAは、フリマアプリで最も人気。
+    %p 出品・購入回数も業界最多です！
+    %p ほしかったあの商品に出会えるかもしれません。
+  .dl-content__dl-badge
+    = link_to image_tag('google-play-badge.png', alt: 'google badge', height: '55', width: 'auto', class: ''), "#"
+    = link_to image_tag('Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917.png', alt: 'apple badge', height: '54', width: 'auto', class: ''), "#"
+  
+.service-feature
+  .title
+    FURIMAの特徴
+    .title__border
+  %ul.lists
+    %li.list
+      .list__image
+        = image_tag 'icon/icon-01.png', class: 'image'
+      .list__subtitle
+        簡単に売り買いできる
+      %p.list__text
+        スマホひとつで、いつでもどこでも簡単に出品・購入が可能！
+    %li.list
+      .list__image
+        = image_tag 'icon/icon-03.png', class: 'image'
+      .list__subtitle
+        売上金は即日振込みに対応
+      %p.list__text
+        午前9時までに振込を依頼いただければ、翌日に指定の口座に入金いたします!
+    %li.list
+      .list__image
+        = image_tag 'icon/icon-04.png', class: 'image'
+      .list__subtitle
+        様々な支払いに対応
+      %p.list__text--center
+        お支払いは、クレジットカードだけでなく、ポイントや売上金など多彩な方法があります。

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,90 +1,9 @@
 = render "layouts/header"
+
 .contents
-  .theme-visual
-    .content
-      .content__title
-        人生を変えるフリマアプリ
-      .content__text
-        %p FURIMAは 誰でも簡単に出品・購入できる
-        %p フリマアプリです"
-      .content__dl-badge
-        = link_to image_tag('google-play-badge.png', alt: 'google badge', height: '55', width: 'auto', class: ''), "#"
-        = link_to image_tag('Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917.png', alt: 'apple badge', height: '54', width: 'auto', class: ''), "#"
-
-  .introduction
-    .title
-      FURIMAが選ばれる3つの理由
-      .title__border
-    %ul.lists
-      %li.list
-        .list__image
-          .number
-            1
-          = image_tag 'pict/pict-reason-01.jpg', class: 'image'
-        .list__subtitle
-          %span 3分
-          ですぐに出品
-        %p.list__text
-          スマホで入力するだけで簡単に出品できる！
-      %li.list
-        .list__image
-          .number
-            2
-          = image_tag 'pict/pict-reason-02.jpg', class: 'image'
-        .list__subtitle
-          %span シンプル
-          で使いやすい
-        %p.list__text
-          めんどくさい入力は必要なく、検索も購入もスムーズ！
-      %li.list
-        .list__image
-          .number
-            3
-          = image_tag 'pict/pict-reason-03.jpg', class: 'image'
-        .list__subtitle
-          手数料
-          %span 業界最安値
-        %p.list__text--center
-          最大3%でお得に出品&購入！
-
-  .dl-content
-    .dl-content__title
-      会員数日本一位
-    .dl-content__text
-      %p FURIMAは、フリマアプリで最も人気。
-      %p 出品・購入回数も業界最多です！
-      %p ほしかったあの商品に出会えるかもしれません。
-    .dl-content__dl-badge
-      = link_to image_tag('google-play-badge.png', alt: 'google badge', height: '55', width: 'auto', class: ''), "#"
-      = link_to image_tag('Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917.png', alt: 'apple badge', height: '54', width: 'auto', class: ''), "#"
+  - unless user_signed_in?
+    = render "app_introduction"
     
-  .service-feature
-    .title
-      FURIMAの特徴
-      .title__border
-    %ul.lists
-      %li.list
-        .list__image
-          = image_tag 'icon/icon-01.png', class: 'image'
-        .list__subtitle
-          簡単に売り買いできる
-        %p.list__text
-          スマホひとつで、いつでもどこでも簡単に出品・購入が可能！
-      %li.list
-        .list__image
-          = image_tag 'icon/icon-03.png', class: 'image'
-        .list__subtitle
-          売上金は即日振込みに対応
-        %p.list__text
-          午前9時までに振込を依頼いただければ、翌日に指定の口座に入金いたします!
-      %li.list
-        .list__image
-          = image_tag 'icon/icon-04.png', class: 'image'
-        .list__subtitle
-          様々な支払いに対応
-        %p.list__text--center
-          お支払いは、クレジットカードだけでなく、ポイントや売上金など多彩な方法があります。
-  
   .products-container
     .products-index
       .title

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -12,5 +12,7 @@
       - if @items
         %ul.lists
           = render "item", items: @items
+  
+      = paginate @items
 
 = render "layouts/footer"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -63,17 +63,19 @@
 
       -# セラーとカレントユーザーが同じ場合下記表示/
       - if user_signed_in? && current_user.id == @item.seller_id
-        %ul.item__edit-btns
-          %li.edit-btn
-            = link_to edit_item_path(@item.id) do
-              編集
-          %li.delete-btn
-            = link_to item_path(@item.id), method: :delete do
-              削除
-      - else 
-        .item__buy-btn
-          = link_to buy_item_purchases_path(@item.id) do
-            購入画面に進む
+        - unless @item.buyer_id.present?
+          %ul.item__edit-btns
+            %li.edit-btn
+              = link_to edit_item_path(@item.id) do
+                編集
+            %li.delete-btn
+              = link_to item_path(@item.id), method: :delete do
+                削除
+      - else
+        - unless @item.buyer_id.present?
+          .item__buy-btn
+            = link_to buy_item_purchases_path(@item.id) do
+              購入画面に進む
 
     %ul.pagenation
       %li.prep-item


### PR DESCRIPTION
# What
・トップページ表示の編集→ログイン状況によって、表示を変える
・詳細ページのボタン表示を変更
# Why
・ログイン済の場合は、商品の一覧を表示する→ユーザーがすぐに商品を目にできるようにする為
・未ログインの場合は、APP紹介と商品一覧を表示させる→新規ユーザー獲得を促す為
・購入済商品は、編集・削除・購入ボタンを押せなくする為