### PR TITLE
パンくず機能 for カテゴリー検索

### DIFF
--- a/app/views/categories/index.html.haml
+++ b/app/views/categories/index.html.haml
@@ -1,4 +1,7 @@
 = render "layouts/header"
+.second-header
+  - breadcrumb :category_index
+  = render "layouts/breadcrumbs"
 
 .wrapper
   .category_search
@@ -18,7 +21,5 @@
             %ul.categories__grandchildren
               - child.children.each do |grandchild|
                 %li= link_to "#{grandchild.name}", category_path(grandchild)
-
-            
 
 = render "layouts/footer"

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -1,4 +1,12 @@
 = render "layouts/header"
+.second-header
+  - if @category.root?
+    - breadcrumb :parent_category
+  - elsif @category.has_children?
+    - breadcrumb :child_category
+  - else
+    - breadcrumb :grandchild_category
+  = render "layouts/breadcrumbs"
 
 .contents
   .category_wrapper

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -45,3 +45,7 @@ crumb :edit_profile do
   link "本人情報", edit_profile_users_path
   parent :mypage
 end
+
+crumb :category_index do
+  link "カテゴリー一覧", categories_path
+end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -49,3 +49,26 @@ end
 crumb :category_index do
   link "カテゴリー一覧", categories_path
 end
+
+crumb :parent_category do |category|
+  category = Category.find(params[:id]).root
+  link "#{category.name}", category_path(category)
+  parent :category_index
+end
+
+crumb :child_category do |category|
+  category = Category.find(params[:id])
+  if category.has_children?
+    link "#{category.name}", category_path(category)
+    parent :parent_category
+  else
+    link "#{category.parent.name}", category_path(category.parent)
+    parent :parent_category
+  end
+end
+
+crumb :grandchild_category do |category|
+  category = Category.find(params[:id])
+  link "#{category.name}", category_path(category)
+  parent :child_category
+end


### PR DESCRIPTION
# What
・カテゴリー別 商品一覧ページにパンくずを追加。

# Why
・商品が所属するカテゴリーを視覚的にわかりやすくするため。
・商品をより探しやすくするため。

### キャプチャ
![f199214d62c2cfe675e5db4a446f95bc](https://user-images.githubusercontent.com/63847712/84117510-9880f700-aa6c-11ea-829c-a3bca2584966.gif)
